### PR TITLE
Bump Alpine to 3.4

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
 RUN echo -e "@edge http://nl.alpinelinux.org/alpine/edge/main\n@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories


### PR DESCRIPTION
Alpine linux released 3.4 version recently. We should use fresh version to be still in the game!